### PR TITLE
New Web-Components (via Tram-Lite)

### DIFF
--- a/about.html
+++ b/about.html
@@ -31,6 +31,12 @@
 
     <title>Daniel Jurman</title>
     <meta name="description" content="" />
+
+    <script
+      defer
+      src="https://unpkg.com/tram-lite@5/output/import-components.js"
+      tl-components="./components/gif-video.html"
+    ></script>
   </head>
   <body>
     <div class="nav">
@@ -47,13 +53,7 @@
     <about-block>
       <about-content>
         <video-container>
-          <video
-            id="about-video"
-            playsinline=""
-            autoplay=""
-            loop=""
-            muted=""
-          ></video>
+          <gif-video id="about-video"></gif-video>
         </video-container>
         <about-description></about-description>
         <about-extras>

--- a/about.html
+++ b/about.html
@@ -35,7 +35,7 @@
     <script
       defer
       src="https://unpkg.com/tram-lite@5/output/import-components.js"
-      tl-components="./components/gif-video.html"
+      tl-components="./components/gif-video.html ./components/back-link.html"
     ></script>
   </head>
   <body>
@@ -61,11 +61,7 @@
           <about-clients></about-clients>
           <about-press></about-press>
         </about-extras>
-        <back-button>
-          <a href="/">
-            <img src="./back-pointing.svg" alt="back" />
-          </a>
-        </back-button>
+        <back-link></back-link>
       </about-content>
     </about-block>
 

--- a/about.js
+++ b/about.js
@@ -13,8 +13,8 @@ function generateAboutBlock(aboutEntry) {
   const { media, content, getInTouch, clients, press } = aboutEntry.fields;
 
   const aboutVideoSrc = media.fields.file.url;
-  const videoElement = aboutElement.querySelector("video-container video");
-  videoElement.src = aboutVideoSrc;
+  const videoElement = aboutElement.querySelector("video-container gif-video");
+  videoElement.setAttribute("src", aboutVideoSrc);
 
   const aboutDescriptionContentHtml = documentToHtmlString(content);
   const aboutDescription = aboutElement.querySelector("about-description");

--- a/components/art-tile.html
+++ b/components/art-tile.html
@@ -1,0 +1,64 @@
+<art-tile>
+  <!-- styles -->
+  <style>
+    :host {
+      margin: 15px;
+      cursor: pointer;
+      transition: all 1s;
+      position: relative;
+    }
+
+    /* don't display titles unless they are on the zoomed in element */
+    art-title,
+    art-publication {
+      display: none;
+    }
+
+    :host([zoomedin]) art-title,
+    :host([zoomedin]) art-publication {
+      display: block;
+    }
+
+    art-title {
+      font-family: "Archivo Black", sans-serif;
+      margin: 6px 0px 4px 0px;
+    }
+
+    art-publication {
+      font-size: 14px;
+      font-style: italic;
+    }
+
+    ::slotted(gif-video),
+    ::slotted(img) {
+      width: 100%;
+      max-width: 100%;
+    }
+  </style>
+
+  <!-- content -->
+  <slot></slot>
+  <art-title>${'title'}</art-title>
+  <art-publication>${'publication'}</art-publication>
+
+  <!-- event listeners -->
+  <script tl-effect>
+    this.addEventListener("click", () => {
+      showcaseImage(this);
+    });
+
+    this.addEventListener("keydown", (event) => {
+      if (event.key === "Enter") {
+        showcaseImage(this);
+      }
+    });
+
+    // disable right click on art-tiles
+    this.addEventListener("contextmenu", (event) => {
+      event.preventDefault();
+    });
+    this.ondragstart = function () {
+      return false;
+    };
+  </script>
+</art-tile>

--- a/components/back-link.html
+++ b/components/back-link.html
@@ -1,0 +1,11 @@
+<back-link>
+  <style>
+    img {
+      height: 1.7em;
+    }
+  </style>
+
+  <a href="/">
+    <img src="./back-pointing.svg" alt="back" />
+  </a>
+</back-link>

--- a/components/gif-video.html
+++ b/components/gif-video.html
@@ -1,0 +1,27 @@
+<gif-video id="" src="">
+  <style>
+    video {
+      width: 100%;
+    }
+  </style>
+
+  <video
+    id="${'id'}"
+    src="${'src'}"
+    playsinline=""
+    autoplay=""
+    loop=""
+    muted=""
+  ></video>
+
+  <script tl-effect>
+    // prevent right click / dragging
+    const videoElement = this.shadowRoot.querySelector("video");
+    videoElement.addEventListener("contextmenu", (event) => {
+      event.preventDefault();
+    });
+    videoElement.ondragstart = function () {
+      return false;
+    };
+  </script>
+</gif-video>

--- a/components/showcase-tile.html
+++ b/components/showcase-tile.html
@@ -1,0 +1,101 @@
+<showcase-tile>
+  <style>
+    :host {
+      container: showcase-tile / inline-size;
+      display: flex;
+      margin: 2em;
+      justify-content: space-around;
+      margin-top: 5em;
+      margin-bottom: 16em;
+    }
+
+    /* if there is no image, set display to none */
+    :host([art-title=""]) {
+      display: none;
+    }
+
+    [art-description] {
+      margin-top: 2em;
+      line-height: 1.3em;
+    }
+
+    [art-publication] {
+      margin-top: 2em;
+    }
+
+    showcase-image {
+      display: flex;
+      flex-direction: column;
+      min-width: 60%;
+    }
+
+    ::slotted(art-tile) {
+      margin: 0px;
+      display: flex;
+      justify-content: center;
+      margin-top: 1.3em;
+    }
+
+    ::slotted(img),
+    ::slotted(gif-video) {
+      margin-top: 4em;
+    }
+
+    showcase-description {
+      margin-right: 10%;
+      margin-left: 20px;
+    }
+
+    showcase-description-slider {
+      position: sticky;
+      top: 10em;
+    }
+
+    h2 {
+      line-height: 1em;
+      font-weight: 400;
+    }
+
+    back-link {
+      display: none;
+    }
+
+    p {
+      word-wrap: break-word;
+      overflow-wrap: break-word;
+      hyphens: manual;
+    }
+
+    @media (width < 1000px) {
+      :host {
+        margin-top: 4em;
+        flex-direction: column-reverse;
+      }
+
+      showcase-description {
+        margin-left: 0px;
+        margin-right: 0px;
+        margin-top: 2em;
+      }
+
+      h2 {
+        margin-top: 1.8em;
+      }
+
+      back-link {
+        display: block;
+      }
+    }
+  </style>
+  <showcase-description>
+    <showcase-description-slider>
+      <h2>${'art-title'}</h2>
+      <p art-description>${'art-description'}</p>
+      <p art-publication>${'art-publication'}</p>
+      <back-link></back-link>
+    </showcase-description-slider>
+  </showcase-description>
+  <showcase-image>
+    <slot></slot>
+  </showcase-image>
+</showcase-tile>

--- a/index.html
+++ b/index.html
@@ -34,6 +34,12 @@
 
     <title>Daniel Jurman</title>
     <meta name="description" content="" />
+
+    <script
+      defer
+      src="https://unpkg.com/tram-lite@5/output/import-components.js"
+      tl-components="./components/gif-video.html"
+    ></script>
   </head>
   <body>
     <div class="nav">

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
     <script
       defer
       src="https://unpkg.com/tram-lite@5/output/import-components.js"
-      tl-components="./components/gif-video.html"
+      tl-components="./components/gif-video.html ./components/art-tile.html"
     ></script>
   </head>
   <body>

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
     <script
       defer
       src="https://unpkg.com/tram-lite@5/output/import-components.js"
-      tl-components="./components/gif-video.html ./components/art-tile.html ./components/back-link.html"
+      tl-components="./components/gif-video.html ./components/art-tile.html ./components/back-link.html ./components/showcase-tile.html"
     ></script>
   </head>
   <body>
@@ -54,13 +54,8 @@
     </div>
 
     <header-spacer></header-spacer>
-    <showcase-tile>
-      <showcase-description>
-        <showcase-description-slider></showcase-description-slider>
-      </showcase-description>
-      <showcase-image></showcase-image>
-    </showcase-tile>
-    <columns-container> </columns-container>
+    <showcase-tile></showcase-tile>
+    <columns-container></columns-container>
 
     <footer>All Work © Daniel Jurman 2023</footer>
   </body>

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
     <script
       defer
       src="https://unpkg.com/tram-lite@5/output/import-components.js"
-      tl-components="./components/gif-video.html ./components/art-tile.html"
+      tl-components="./components/gif-video.html ./components/art-tile.html ./components/back-link.html"
     ></script>
   </head>
   <body>
@@ -56,11 +56,7 @@
     <header-spacer></header-spacer>
     <showcase-tile>
       <showcase-description>
-        <showcase-description-slider>
-          <showcase-back-button style="display: none"
-            >back</showcase-back-button
-          >
-        </showcase-description-slider>
+        <showcase-description-slider></showcase-description-slider>
       </showcase-description>
       <showcase-image></showcase-image>
     </showcase-tile>

--- a/main.js
+++ b/main.js
@@ -42,22 +42,8 @@ function generateMediaElement(media, isExtraMedia) {
     return mediaElement;
   }
   if (contentType.match("video")) {
-    const mediaElement = document.createElement("video");
+    const mediaElement = document.createElement("gif-video");
     mediaElement.setAttribute(isExtraMedia ? "src" : "data-src", url);
-    mediaElement.controls = false;
-    mediaElement.autoplay = true;
-    mediaElement.playsInline = true;
-    mediaElement.loop = true;
-    mediaElement.setAttribute("muted", "");
-
-    // prevent right click / dragging
-    mediaElement.addEventListener("contextmenu", (event) => {
-      event.preventDefault();
-    });
-    mediaElement.ondragstart = function () {
-      return false;
-    };
-
     return mediaElement;
   }
 
@@ -169,7 +155,7 @@ const intersectionObserver = new IntersectionObserver((entries) => {
       intersectionObserver.unobserve(entry.target);
       const mediaElements = [
         ...entry.target.querySelectorAll("img"),
-        ...entry.target.querySelectorAll("video"),
+        ...entry.target.querySelectorAll("gif-video"),
       ];
       mediaElements.forEach((mediaElement) => {
         const srcUrl = mediaElement.getAttribute("data-src");

--- a/main.js
+++ b/main.js
@@ -73,29 +73,7 @@ function generateArtTile(artTile) {
   artTileElement.setAttribute("data-publication", publication);
   artTileElement.setAttribute("data-description", description || "");
   const mediaElement = generateMediaElement(media);
-  artTileElement.innerHTML = `
-		${mediaElement.outerHTML}
-		<art-title>${title}</art-title>
-		<art-publication>${publication}</art-publication>
-	`;
-
-  // click action to showcase an image
-  artTileElement.onclick = () => {
-    showcaseImage(artTileElement);
-  };
-  artTileElement.addEventListener("keydown", (event) => {
-    if (event.key === "Enter") {
-      showcaseImage(artTileElement);
-    }
-  });
-
-  // disable right click on art-tiles
-  artTileElement.addEventListener("contextmenu", (event) => {
-    event.preventDefault();
-  });
-  artTileElement.ondragstart = function () {
-    return false;
-  };
+  artTileElement.append(mediaElement);
 
   artTileElements.push(artTileElement);
   intersectionObserver.observe(artTileElement);

--- a/showcaseImage.js
+++ b/showcaseImage.js
@@ -20,7 +20,6 @@ function showcaseImageStart() {
     showcaseTile.innerHTML = `
       <showcase-description>
         <showcase-description-slider>
-          <showcase-back-button style="display:none">back</showcase-back-button>
         </showcase-description-slider>
       </showcase-description>
       <showcase-image></showcase-image>
@@ -28,10 +27,6 @@ function showcaseImageStart() {
 
     processArtTiles();
   }
-}
-
-function goBack() {
-  history.back();
 }
 
 function getExtraMedia(artTile) {
@@ -73,9 +68,7 @@ function showcaseImage(artTile) {
       <p style="margin-top: 2em;"><i>${artTile.getAttribute(
         "data-publication"
       )}</i></p>
-      <showcase-back-button onclick="goBack()">
-        <img src="./back-pointing.svg" alt="back" />
-      </showcase-back-button>
+      <back-link></back-link>
     </showcase-description-slider>
   `;
 

--- a/showcaseImage.js
+++ b/showcaseImage.js
@@ -16,14 +16,7 @@ function showcaseImageStart() {
   // do not show showcase at the top of the page
   if (!window.location.hash) {
     const showcaseTile = document.querySelector("showcase-tile");
-    showcaseTile.style.display = "none";
-    showcaseTile.innerHTML = `
-      <showcase-description>
-        <showcase-description-slider>
-        </showcase-description-slider>
-      </showcase-description>
-      <showcase-image></showcase-image>
-    `;
+    // clear content? remove attributes?
 
     processArtTiles();
   }
@@ -48,31 +41,24 @@ function showcaseImage(artTile) {
 
   // append this art tile to the top showcase tile (moving it from where it was in the grid)
   const showcaseTile = document.querySelector("showcase-tile");
-  showcaseTile.style.display = "";
-  showcaseTile.querySelector("showcase-image").innerHTML = "";
-  showcaseTile.querySelector("showcase-image").appendChild(artTile);
+  showcaseTile.setAttribute("art-title", artTile.getAttribute("data-title"));
+
+  const showcaseImages = [];
+  showcaseImages.push(artTile);
   // append the other images
-  getExtraMedia(artTile).forEach((img) =>
-    showcaseTile.querySelector("showcase-image").appendChild(img)
-  );
+  getExtraMedia(artTile).forEach((img) => showcaseImages.push(img));
 
-  const showcaseDescription = showcaseTile.querySelector(
-    "showcase-description"
-  );
-  showcaseDescription.innerHTML = `
-    <showcase-description-slider>
-      <h2>${artTile.getAttribute("data-title")}</h2>
-      <p style="margin-top: 2em; line-height: 1.3em;">${artTile.getAttribute(
-        "data-description"
-      )}</p>
-      <p style="margin-top: 2em;"><i>${artTile.getAttribute(
-        "data-publication"
-      )}</i></p>
-      <back-link></back-link>
-    </showcase-description-slider>
-  `;
+  // replace all the existing images (including extras) with the new set of images
+  showcaseTile.replaceChildren(...showcaseImages);
 
-  // scrollTo({ top: 0, behavior: "smooth" });
+  showcaseTile.setAttribute(
+    "art-description",
+    artTile.getAttribute("data-description")
+  );
+  showcaseTile.setAttribute(
+    "art-publication",
+    artTile.getAttribute("data-publication")
+  );
 }
 
 window.onpopstate = (event) => {

--- a/styles.css
+++ b/styles.css
@@ -5,69 +5,6 @@ body {
   font-family: "Courier Prime", monospace;
 }
 
-p {
-  word-wrap: break-word;
-  overflow-wrap: break-word;
-  hyphens: manual;
-}
-
-showcase-tile {
-  display: flex;
-  margin: 2em;
-  justify-content: space-around;
-  margin-top: 9em;
-  margin-bottom: 16em;
-}
-
-showcase-image {
-  display: flex;
-  flex-direction: column;
-  min-width: 60%;
-}
-showcase-image > art-tile {
-  margin: 0px;
-  display: flex;
-  justify-content: center;
-}
-
-showcase-image > img,
-showcase-image > gif-video {
-  margin-top: 4em;
-}
-
-showcase-description {
-  margin-right: 10%;
-  margin-left: 20px;
-}
-
-showcase-description-slider {
-  position: sticky;
-  top: 12.75em;
-}
-
-showcase-description > * > h2 {
-  margin-top: 0px;
-  line-height: 1em;
-  font-weight: 400;
-}
-
-@media screen and (max-width: 1000px) {
-  showcase-tile {
-    margin-top: 4em;
-    flex-direction: column-reverse;
-  }
-
-  showcase-description {
-    margin-left: 0px;
-    margin-right: 0px;
-    margin-top: 2em;
-  }
-
-  showcase-description > h2 {
-    margin-top: 1.8em;
-  }
-}
-
 /* Component Styles */
 body {
   margin: 0px;

--- a/styles.css
+++ b/styles.css
@@ -51,20 +51,6 @@ showcase-description > * > h2 {
   font-weight: 400;
 }
 
-showcase-back-button {
-  cursor: pointer;
-  display: none;
-  font-size: 0.9em;
-  font-weight: 700;
-  color: #808080;
-  transition: all 0.25s;
-  padding-top: 1em;
-}
-
-showcase-back-button > img {
-  height: 1.7em;
-}
-
 @media screen and (max-width: 1000px) {
   showcase-tile {
     margin-top: 4em;
@@ -79,10 +65,6 @@ showcase-back-button > img {
 
   showcase-description > h2 {
     margin-top: 1.8em;
-  }
-
-  showcase-back-button {
-    display: inline-block;
   }
 }
 
@@ -265,10 +247,6 @@ about-links > a > img {
   max-width: 2em;
   max-height: 2em;
   margin: 0.5em;
-}
-
-back-button > a > img {
-  height: 1.7em;
 }
 
 /* desktop mode */

--- a/styles.css
+++ b/styles.css
@@ -31,7 +31,7 @@ showcase-image > art-tile {
 }
 
 showcase-image > img,
-showcase-image > video {
+showcase-image > gif-video {
   margin-top: 4em;
 }
 
@@ -183,7 +183,7 @@ art-tile {
   position: relative;
 }
 
-art-tile > video,
+art-tile > gif-video,
 art-tile > img {
   width: 100%;
   max-width: 100%;
@@ -268,10 +268,6 @@ about-content {
   flex-wrap: wrap;
 }
 
-video-container > video {
-  width: 100%;
-  margin-top: 1em;
-}
 video-container {
   display: block;
   width: 100%;

--- a/styles.css
+++ b/styles.css
@@ -86,10 +86,6 @@ showcase-back-button > img {
   }
 }
 
-art-title {
-  font-family: "Archivo Black", sans-serif;
-}
-
 /* Component Styles */
 body {
   margin: 0px;
@@ -146,17 +142,6 @@ header-spacer {
   padding-bottom: 60px;
 }
 
-/* don't display titles unless they are on the zoomed in element */
-art-title,
-art-publication {
-  display: none;
-}
-
-art-tile[zoomedin] art-title,
-art-tile[zoomedin] art-publication {
-  display: block;
-}
-
 columns-container {
   display: grid;
   transition: 1s;
@@ -175,20 +160,6 @@ tile-column {
 }
 
 /* main page */
-
-art-tile {
-  margin: 15px;
-  cursor: pointer;
-  transition: all 1s;
-  position: relative;
-}
-
-art-tile > gif-video,
-art-tile > img {
-  width: 100%;
-  max-width: 100%;
-  /* min-height: 500px; */
-}
 
 tile-column art-tile::before {
   content: "";
@@ -232,15 +203,6 @@ tile-column art-tile:hover::after {
   height: 250px;
   max-width: 100%;
   margin-bottom: 4px;
-}
-
-art-title {
-  margin: 6px 0px 4px 0px;
-}
-
-art-publication {
-  font-size: 14px;
-  font-style: italic;
 }
 
 ul {


### PR DESCRIPTION
## Summary

Extract out blocks of common code (specifically ones that used `innerHTML` to inject HTML into dedicated web-components. 

This should help better-organize the styles and content of these components.

### PR structure
Each commit focuses on an individual component. The hope is that this should make it easier to review. If future changes are required, they will be rebased on the relevant commit. 

## New Components

### `gif-video`
This component represents a repeating video with no controls. It's one of the more basic components, and helps extract out the attributes that are common here.

### `back-link`
Another basic component, this just represents the common back hand icon 👈 that is used throughout the app.

### `art-tile`
This component represents a single tile that is either used in a column, or in the showcase. It contains the meta-data for the title, description, and publisher (even if those attributes aren't immediately visible).

### `showcase-tile`
This component represents the top-level element that displays when a tile is clicked. It has unique behavior when there is no active tile, and when the display is smaller.

## Known Changes
While many attempts were made to make this as 1-to-1 with the existing site as possible, there are some changes that were made, for simplicity sake, or because stylistically they seemed more appropriate. Other unknown side-effects may have occurred in this migration, but I've gone through side-by-side testing to try to minimize these as much as possible.

### Functionality changes
* Back buttom goes straight to `/`

### Style changes
* Top-margin for spotlight-tile is reduced

## Side-by-side
For the following images, the branch here is on the left, and the production site is on the right

Main Page, 3 columns
![image](https://github.com/ethanjurman/danjurman-website/assets/326557/bf42c7c8-b957-4e5b-a81d-e0f23db4bfdc)

Showcase Tile
![image](https://github.com/ethanjurman/danjurman-website/assets/326557/58b5ecc9-8c57-4ee2-82b9-d9934a6644a0)

Showcase w/ Extra Images
![image](https://github.com/ethanjurman/danjurman-website/assets/326557/95bb0797-daf4-4c2c-a0f2-e88b95c575d6)

Single Column View
![image](https://github.com/ethanjurman/danjurman-website/assets/326557/7dc1c04b-68c1-46ce-b37b-53a2932dd787)

Showcase w/ Single Column View
![image](https://github.com/ethanjurman/danjurman-website/assets/326557/6c151465-9a57-4749-a881-dcc9b1f24396)

About Page
![image](https://github.com/ethanjurman/danjurman-website/assets/326557/befba619-e661-46e6-a487-4e3461d81eff)


About Page (single Column)
![image](https://github.com/ethanjurman/danjurman-website/assets/326557/35c60654-873a-4e4d-9580-27d70a1416e9)



## Rollback strategy
- [x] PR Revert